### PR TITLE
ゲームオブジェクトがフリーズした後もblockinfoを持ち続けたらまたその状態でネットワークを構築することが可能になってしまうので、fr…

### DIFF
--- a/Assets/Scripts/Block/BlockInfo/BlockInfo.cs
+++ b/Assets/Scripts/Block/BlockInfo/BlockInfo.cs
@@ -69,6 +69,11 @@ public abstract class BlockInfo : MonoBehaviour
         return neighborEdge;
     }
 
+    public void RemoveEdges()
+    {
+        neighborEdge = null;
+    }
+
     public void EnableCollider()
     {
         myCollider.enabled = true;

--- a/Assets/Scripts/NetWork/NetWork.cs
+++ b/Assets/Scripts/NetWork/NetWork.cs
@@ -125,6 +125,9 @@ public class NetWork : MonoBehaviour
         }
         //ネットワークからそのノードを削除
         allNodes.Remove(originNode);
+        //ブロックの情報も失わせる。
+        originNode.GetComponent<BlockInfo>().enabled = false;
+
     }
 
     //ネットワークから特定のサブネットワークを切り離すメソッド


### PR DESCRIPTION
…eezeと同時に消去しておく必要があったため、修正した